### PR TITLE
Improve provider behaviour

### DIFF
--- a/lib/avalon.ex
+++ b/lib/avalon.ex
@@ -2,6 +2,8 @@ defmodule Avalon do
   @moduledoc """
   Documentation for `Avalon`.
   """
+  alias Avalon.Conversation.Message
+
   @chat_schema [
     provider: [
       type: :atom,
@@ -16,16 +18,16 @@ defmodule Avalon do
     ]
   ]
   @doc """
-  Send a `Conversation.t()` to an LLM and get back a `Message.t()`.
+  Send an array of `Message.t()` to an LLM and get back a `Message.t()`.
 
   ## Options
   #{NimbleOptions.docs(@chat_schema)}
   """
-  @spec chat(Conversation.t(), keyword) ::
-          {:ok, Conversation.t()} | {:error, NimbleOptions.error()}
-  def chat(conversation, opts \\ []) do
+  @spec chat([Messages.t()], keyword) ::
+          {:ok, Message.t()} | {:error, NimbleOptions.error()}
+  def chat(messages, opts \\ []) do
     case NimbleOptions.validate(opts, @chat_schema) do
-      {:ok, opts} -> opts[:provider].chat(conversation, opts[:provider_opts])
+      {:ok, opts} -> opts[:provider].chat(messages, opts[:provider_opts])
       {:error, error} -> {:error, error}
     end
   end

--- a/lib/avalon/error.ex
+++ b/lib/avalon/error.ex
@@ -1,0 +1,19 @@
+defmodule Avalon.Error do
+  @moduledoc """
+  Standardized error structure for Avalon operations.
+  """
+  defstruct [
+    # Error category (e.g. :provider, :validation, :tool)
+    :type,
+    # Human-readable error description
+    :message,
+    # Additional context (raw response, params, provider, etc.)
+    :metadata
+  ]
+
+  @type t :: %__MODULE__{
+          type: atom(),
+          message: String.t(),
+          metadata: map()
+        }
+end

--- a/lib/avalon/provider.ex
+++ b/lib/avalon/provider.ex
@@ -1,40 +1,209 @@
 defmodule Avalon.Provider do
   @moduledoc """
-  Defines the behaviour for LLM providers in Avalon.
-  Providers implement this behaviour to support different LLM services
-  like OpenAI, Anthropic, Together, etc.
+  Defines the standardized interface for LLM service providers in Avalon.
+
+  ## Overview
+
+  The Provider behavior establishes a contract for integrating different Large Language Model
+  services (OpenAI, Anthropic, Azure, etc.) into Avalon's framework. It breaks down the LLM
+  interaction process into discrete, composable steps that enable:
+
+  - Consistent error handling across providers
+  - Fine-grained telemetry and observability
+  - Standardized message formatting
+  - Schema validation for structured outputs
+  - Tool/function calling capabilities
+
+  ## Provider Lifecycle
+
+  The standard chat flow follows these steps:
+
+  1. **Validation** - Verify options against provider-specific requirements
+  2. **Preparation** - Transform messages into provider-specific format
+  3. **Request** - Execute the API call to the LLM service
+  4. **Response Processing** - Convert provider response to standard Message format
+  5. **Structure Validation** - Ensure response conforms to expected schema (if specified)
+
+  ## Usage
+
+  To implement a provider, use the `Avalon.Provider` behavior and implement the required
+  callbacks:
+
+  ```
+  defmodule MyApp.CustomProvider do
+    use Avalon.Provider
+
+    @impl true
+    def validate_options(opts) do
+      # Validate provider-specific options
+    end
+
+    @impl true
+    def prepare_chat_body(messages, opts) do
+      # Transform messages to provider format
+    end
+
+    # Implement other required callbacks...
+  end
+  ```
+
+  Then use your provider with the conversation API:
+
+  ```
+  Avalon.chat(conversation, provider: MyApp.CustomProvider, provider_opts: [temperature: 0.7])
+  ```
+
+  ## Model Discovery
+
+  Providers expose their available models through the `list_models/0` and `get_model/1` callbacks,
+  allowing clients to discover capabilities and constraints without hardcoding provider-specific
+  knowledge.
+
+  ## Structured Output
+
+  The `ensure_structure/2` callback enables validation of LLM responses against a schema,
+  supporting use cases that require structured data rather than free-form text.
+
+  ## Tool Integration
+
+  Providers can expose external tools to LLMs through the `format_tool/1` callback, which
+  transforms Avalon tool modules into provider-specific function specifications.
+
+  ## Error Handling
+
+  All callbacks return either `{:ok, result}` or `{:error, Error.t()}`, providing consistent
+  error propagation throughout the framework. The default implementation of `chat/2` handles
+  this error chain automatically.
+
+  ## Extensibility
+
+  The behavior's design allows for extension through:
+
+  - Custom telemetry spans
+  - Provider-specific message metadata
+  - Capability-based feature detection
+  - Streaming responses (when supported)
   """
 
   alias Avalon.Error
-  alias Avalon.Message
+  alias Avalon.Conversation.Message
   alias Avalon.Provider.Model
 
+  @doc """
+  Returns all available models from this provider.
+
+  ## Expected Behavior
+  - Should return a list of `Avalon.Provider.Model` structs
+  - Each model must include capability metadata
+  - Models should be sorted by recommended usage
+  """
   @callback list_models() :: [Model.t()]
 
+  @doc """
+  Retrieves detailed model information by name.
+
+  ## Parameters
+  - `name`: String representing the model identifier
+
+  ## Returns
+  - `{:ok, Model.t()}` if found
+  - `{:error, :not_found}` for unknown models
+
+  ## Implementation Notes
+  - Should validate model availability against provider's current offerings
+  """
   @callback get_model(name :: String.t()) :: {:ok, Model.t()} | {:error, :not_found}
 
+  @doc """
+  Converts provider-specific response format to standardized Message struct.
+
+  ## Parameters
+  - `response`: Raw API response from provider
+
+  ## Expected Behavior
+  - Handles both success and error response formats
+  - Extracts tool calls when present
+  - Preserves provider-specific metadata in message struct
+
+  ## Error Handling
+  - Must return `{:error, Error.t()}` for malformed responses
+  """
   @callback response_to_message(response :: map()) :: {:ok, Message.t()} | {:error, Error.t()}
 
-  @callback validate_options(opts :: keyword()) :: {:ok, keyword} | {:error, Error.t()}
+  @doc """
+  Validates provider-specific options and configuration.
 
+  ## Parameters
+  - `opts`: Keyword list of options passed to chat/2
+
+  ## Returns
+  - `{:ok, validated_opts}` with normalized options
+  - `{:error, Error.t()}` for invalid configurations
+  """
+  @callback validate_options(opts :: keyword()) :: {:ok, keyword()} | {:error, Error.t()}
+
+  @doc """
+  Transforms conversation messages into provider-specific API request body.
+
+  ## Parameters
+  - `messages`: List of `Message.t()` structs
+  - `opts`: Validated provider options
+
+  ## Expected Behavior
+  - Converts message structs to provider's required format
+  - Handles special cases like system prompts and tool messages
+  - Adds provider-specific parameters from options
+  """
   @callback prepare_chat_body(messages :: [Message.t()], opts :: keyword()) ::
               {:ok, map()} | {:error, Error.t()}
 
-  @callback chat(messages :: [Message.t()], opts :: keyword()) ::
+  @doc """
+  Executes the API request to the LLM provider.
+
+  ## Parameters
+  - `body`: Prepared request body from prepare_chat_body/2
+  - `opts`: Validated provider options
+
+  ## Expected Behavior
+  - Handles HTTP transport and network errors
+  - Implements retry logic for rate limits
+  - Returns raw provider response for processing
+  """
+  @callback request_chat(body :: map(), opts :: keyword()) ::
+              {:ok, map()} | {:error, Error.t()}
+
+  @doc """
+  Validates and transforms message structure against output schema.
+
+  ## Parameters
+  - `message`: Message.t() from response_to_message/1
+  - `opts`: Original provider options containing output_schema
+
+  ## Expected Behavior
+  - When output_schema is present:
+    - Validates message content against schema
+    - Transforms content to match schema types
+  - Returns original message when no schema specified
+
+  ## Error Handling
+  - Returns {:error, Error.t()} with validation details on failure
+  """
+  @callback ensure_structure(message :: Message.t(), opts :: keyword()) ::
               {:ok, Message.t()} | {:error, Error.t()}
 
-  @callback ensure_structure(Message.t(), opts :: keyword()) ::
-              {:ok, Message.t()} | {:error, Error.t()}
+  @doc """
+  Converts a tool module into provider-specific schema format.
 
-  @callback request_chat(
-              body :: map(),
-              opts :: keyword()
-            ) :: {:ok, map()} | {:error, Error.t()}
+  ## Parameters
+  - `tool_module`: Module implementing Avalon.Tool behavior
 
+  ## Expected Behavior
+  - Returns tool specification in provider's required format
+  - Should handle parameter validation schemas
+  """
   @callback format_tool(tool_module :: module()) :: map()
 
   @optional_callbacks [
-    chat: 2,
     format_tool: 1
   ]
 
@@ -42,17 +211,107 @@ defmodule Avalon.Provider do
     quote do
       @behaviour Avalon.Provider
 
-      @impl true
+      @doc """
+      Processes a complete chat interaction with the LLM provider, including telemetry instrumentation.
+
+      This function orchestrates the entire chat lifecycle by sequentially calling the provider's
+      implementation of each required callback:
+
+      1. `validate_options/1` - Validates and normalizes provider options
+      2. `prepare_chat_body/2` - Transforms messages into provider-specific format
+      3. `request_chat/2` - Executes the API request to the LLM
+      4. `response_to_message/1` - Converts provider response to standard Message format
+      5. `ensure_structure/2` - Validates response against schema (if specified)
+
+      ## Parameters
+      - `messages`: List of `Message.t()` structs representing the conversation history
+      - `opts`: Keyword list of provider-specific options
+
+      ## Returns
+      - `{:ok, message, metadata}` - Successful response with timing information
+      - `{:error, error, metadata}` - Error with details and timing information
+
+      ## Telemetry
+      Emits the following telemetry events:
+      - `[:avalon, :provider, :chat, :start]` - When chat begins
+      - `[:avalon, :provider, :chat, :stop]` - When chat completes
+      - `[:avalon, :provider, :chat, :exception]` - If an exception occurs
+
+      Each step in the process also emits its own telemetry events.
+      """
       def chat(messages, opts) do
-        with {:ok, opts} <- validate_options(opts),
-             {:ok, body} <- prepare_chat_body(messages, opts),
-             {:ok, response} <- request_chat(body, opts),
-             {:ok, message} <- response_to_message(response),
-             {:ok, message} <- ensure_structure(message, opts) do
-          {:ok, message}
-        else
-          {:error, error} -> {:error, error}
-        end
+        start_time = System.monotonic_time()
+
+        :telemetry.span([:avalon, :provider, :chat], %{messages: length(messages)}, fn ->
+          result =
+            with {:ok, opts} <- with_telemetry(:validate_options, [opts], &validate_options/1),
+                 {:ok, body} <-
+                   with_telemetry(:prepare_chat_body, [messages, opts], &prepare_chat_body/2),
+                 {:ok, response} <- with_telemetry(:request_chat, [body, opts], &request_chat/2),
+                 {:ok, message} <-
+                   with_telemetry(:response_to_message, [response], &response_to_message/1),
+                 {:ok, message} <-
+                   with_telemetry(:ensure_structure, [message, opts], &ensure_structure/2) do
+              {:ok, message}
+            else
+              {:error, error} -> {:error, error}
+            end
+
+          # Calculate duration for telemetry but don't include it in the return value
+          duration = System.monotonic_time() - start_time
+          {result, %{duration: duration}}
+        end)
+      end
+
+      defp with_telemetry(:validate_options, [opts], fun) do
+        metadata = %{
+          provider: __MODULE__,
+          step: :validate_options,
+          opts: opts
+        }
+
+        :telemetry.span(
+          [:avalon, :provider, :validate_options],
+          metadata,
+          fn ->
+            result = fun.(opts)
+            {result, metadata}
+          end
+        )
+      end
+
+      defp with_telemetry(step, [arg1, arg2], fun) do
+        metadata = %{
+          provider: __MODULE__,
+          step: step,
+          opts: arg2
+        }
+
+        :telemetry.span(
+          [:avalon, :provider, step],
+          metadata,
+          fn ->
+            result = fun.(arg1, arg2)
+            {result, metadata}
+          end
+        )
+      end
+
+      defp with_telemetry(step, [arg], fun) do
+        metadata = %{
+          provider: __MODULE__,
+          step: step,
+          opts: %{}
+        }
+
+        :telemetry.span(
+          [:avalon, :provider, step],
+          metadata,
+          fn ->
+            result = fun.(arg)
+            {result, metadata}
+          end
+        )
       end
     end
   end


### PR DESCRIPTION
Instead of explicitly defining `chat`, this sets up the provider behaviour with multiple steps that are chained together in a using macro. This will permit event-based hooks, more flexibility, and more guidance as I tighten up the language here.