### PR TITLE
Add streaming support to the provider contract

### DIFF
--- a/lib/avalon.ex
+++ b/lib/avalon.ex
@@ -31,4 +31,24 @@ defmodule Avalon do
       {:error, error} -> {:error, error}
     end
   end
+
+  @doc """
+  Stream an array of `Message.t()` to an LLM, invoking `on_chunk` for each
+  `Avalon.StreamChunk` as it arrives and returning the fully-assembled
+  `Message.t()` once the stream completes.
+
+  The provider must implement the optional `c:Avalon.Provider.stream_chat/3`
+  callback.
+
+  ## Options
+  #{NimbleOptions.docs(@chat_schema)}
+  """
+  @spec stream([Message.t()], (Avalon.StreamChunk.t() -> any()), keyword()) ::
+          {:ok, Message.t()} | {:error, NimbleOptions.error()}
+  def stream(messages, on_chunk, opts \\ []) when is_function(on_chunk, 1) do
+    case NimbleOptions.validate(opts, @chat_schema) do
+      {:ok, opts} -> opts[:provider].stream_chat(messages, opts[:provider_opts], on_chunk)
+      {:error, error} -> {:error, error}
+    end
+  end
 end

--- a/lib/avalon/provider.ex
+++ b/lib/avalon/provider.ex
@@ -88,6 +88,7 @@ defmodule Avalon.Provider do
   alias Avalon.Error
   alias Avalon.Conversation.Message
   alias Avalon.Provider.Model
+  alias Avalon.StreamChunk
 
   @doc """
   Returns all available models from this provider.
@@ -268,10 +269,33 @@ defmodule Avalon.Provider do
   @callback transcribe(audio :: binary() | String.t(), opts :: keyword()) ::
               {:ok, map()} | {:error, Error.t()}
 
+  @doc """
+  Streams a chat completion, invoking `on_chunk` for each incremental update.
+
+  ## Parameters
+  - `messages`: List of `Message.t()` structs representing the conversation history
+  - `opts`: Provider options, as for `chat/2`
+  - `on_chunk`: A function invoked with each `Avalon.StreamChunk` as it arrives
+
+  ## Expected Behavior
+  - Invokes `on_chunk` with `%StreamChunk{content: delta}` for each text fragment
+  - Invokes `on_chunk` with `%StreamChunk{done: true}` once the stream ends
+  - Accumulates the streamed deltas and returns the fully assembled `Message.t()`
+
+  ## Error Handling
+  - Returns `{:error, Error.t()}` on transport or protocol failure
+  """
+  @callback stream_chat(
+              messages :: [Message.t()],
+              opts :: keyword(),
+              on_chunk :: (StreamChunk.t() -> any())
+            ) :: {:ok, Message.t()} | {:error, Error.t()}
+
   @optional_callbacks [
     format_tool: 1,
     embed: 2,
-    transcribe: 2
+    transcribe: 2,
+    stream_chat: 3
   ]
 
   defmacro __using__(_opts) do

--- a/lib/avalon/stream_chunk.ex
+++ b/lib/avalon/stream_chunk.ex
@@ -1,0 +1,24 @@
+defmodule Avalon.StreamChunk do
+  @moduledoc """
+  An incremental update emitted during a streaming chat completion.
+
+  A provider's `c:Avalon.Provider.stream_chat/3` invokes the caller's callback
+  with a `StreamChunk` for each delta:
+
+    * `:content` — a text fragment of the assistant's reply
+    * `:tool_call` — a completed tool call (when the model calls a tool)
+    * `:done` — `true` on the final chunk, signalling the end of the stream
+
+  A given chunk typically carries exactly one of `:content` or `:tool_call`, or
+  sets `:done`.
+  """
+
+  @derive {JSON.Encoder, only: [:content, :tool_call, :done]}
+  defstruct content: nil, tool_call: nil, done: false
+
+  @type t :: %__MODULE__{
+          content: String.t() | nil,
+          tool_call: map() | nil,
+          done: boolean()
+        }
+end

--- a/test/avalon/stream_test.exs
+++ b/test/avalon/stream_test.exs
@@ -1,0 +1,52 @@
+defmodule Avalon.StreamTest do
+  use ExUnit.Case, async: true
+
+  alias Avalon.Conversation.Message
+  alias Avalon.StreamChunk
+
+  defmodule EchoStreamProvider do
+    use Avalon.Provider
+
+    @impl true
+    def stream_chat(_messages, _opts, on_chunk) do
+      on_chunk.(%StreamChunk{content: "Hel"})
+      on_chunk.(%StreamChunk{content: "lo"})
+      on_chunk.(%StreamChunk{done: true})
+      {:ok, Message.new(role: :assistant, content: "Hello")}
+    end
+
+    @impl true
+    def validate_options(opts), do: {:ok, opts}
+    @impl true
+    def prepare_chat_body(_messages, _opts), do: {:ok, %{}}
+    @impl true
+    def request_chat(_body, _opts), do: {:ok, %{}}
+    @impl true
+    def response_to_message(_response), do: {:ok, Message.new(role: :assistant, content: "")}
+    @impl true
+    def ensure_structure(message, _opts), do: {:ok, message}
+    @impl true
+    def list_models, do: []
+    @impl true
+    def get_model(_name), do: {:error, :not_found}
+  end
+
+  test "stream/3 dispatches to the provider, delivers chunks, and returns the message" do
+    test_pid = self()
+
+    assert {:ok, %Message{role: :assistant, content: "Hello"}} =
+             Avalon.stream(
+               [Message.new(role: :user, content: "hi")],
+               fn chunk -> send(test_pid, {:chunk, chunk}) end,
+               provider: EchoStreamProvider
+             )
+
+    assert_receive {:chunk, %StreamChunk{content: "Hel"}}
+    assert_receive {:chunk, %StreamChunk{content: "lo"}}
+    assert_receive {:chunk, %StreamChunk{done: true}}
+  end
+
+  test "stream/3 returns a validation error when no provider is given" do
+    assert {:error, _} = Avalon.stream([], fn _ -> :ok end, [])
+  end
+end


### PR DESCRIPTION
Adds an optional streaming path alongside the existing request/response `chat/2`.

## What

- **`Avalon.StreamChunk`** — an incremental update emitted during a streaming completion (`:content` text fragment, `:tool_call`, or `:done`).
- **`Avalon.Provider.stream_chat/3`** — new *optional* callback. Given messages, opts, and an `on_chunk` function, it invokes the callback for each `StreamChunk` and returns the fully-assembled `Message.t()`.
- **`Avalon.stream/3`** — top-level dispatcher mirroring `chat/2`; validates options and delegates to the provider's `stream_chat/3`.

## Notes

- Streaming transport (SSE parsing, `Req` `into:`, etc.) is intentionally left to each provider, since it is inherently provider-specific.
- Tested with a stub provider that emits chunks and returns the final message, plus the no-provider validation-error path.
